### PR TITLE
Added before_get and after_get arrays and methods

### DIFF
--- a/MY_Model.php
+++ b/MY_Model.php
@@ -159,10 +159,7 @@ class MY_Model extends CI_Model {
 		$where =& func_get_args();
 		$this->_set_where($where);
 		
-		$this->_run_before_get();
-		$result = $this->get_all();
-		$this->_run_after_get($result);
-		return $result;
+		return $this->get_all();
 	}
 	
 	/**
@@ -171,8 +168,11 @@ class MY_Model extends CI_Model {
 	 * @return array
 	 */
 	public function get_all() {
-		return $this->db->get($this->_table)
-						->result();
+		$this->_run_before_get();
+		$result = $this->db->get($this->_table)
+							->result();
+		$this->_run_after_get($result);
+		return $result;
 	}
 	
 	/**


### PR DESCRIPTION
I've modified the get methods (get, get_by and get_all) to run any methods in the before_get and after_get arrays. What this allows you to do is set up methods in your models to run before, which would be for joins or any other custom sql you want to use, and then run methods after which would be for attaching other data. Here's a sample model I'm using.

```
class Nurse_model extends MY_Model {

    public function __construct(){
        parent::__construct();

        $this->before_get = array('join_user');
        $this->after_get = array('get_user');
    }

    public function join_user(){
        $this->db->select('nurses.*, users.first_name, users.last_name, users.city');
        $this->db->join('users', 'users.id = nurses.user_id');
    }

    public function get_user($row){
        $this->db->where('id', $row->user_id);
        $row->user = $this->db->get('users')->row();
    }

}
```

So I'm joining my users table so that I can do some order_by stuff on some fields from the users table, and then I'm attaching the user object for each nurse record afterward.

I've got some other models that essentially chain gets from other models, so I end up with something like $blog_post->comments[0]->user->id.  Now, there are a couple issues with this, obviously the more data that's being retrieved, the slower it's going to get, and if you happen to have 2 models both getting data from each other, you could end up with an infinite loop.
