### PR TITLE
 added a line to make it return null if nothing is found

### DIFF
--- a/lib/MY_Model.php
+++ b/lib/MY_Model.php
@@ -130,6 +130,9 @@ class MY_Model extends CI_Model {
 		$row = $this->db->get($this->_table)
 						->row();
 		$this->_run_after_get($row);
+		
+		$row = (is_array($row) and empty($row)) ? null : $row;
+		
 		return $row;
 	}
 	


### PR DESCRIPTION
the get_by function returns an empty array if no record is found even when fetching a single record .. added a line to make it return null if nothing is found .. makes it more logical
