### PR TITLE
Return correct insert_id when using a after_create callback

### DIFF
--- a/lib/MY_Model.php
+++ b/lib/MY_Model.php
@@ -526,7 +526,7 @@ class MY_Model extends CI_Model
         
             foreach ($this->$name as $method)
             {
-                $data = call_user_func_array(array($this, $method), $params);
+                $data += call_user_func_array(array($this, $method), $params);
             }
         }
         


### PR DESCRIPTION
When using an after create callback in which there's another insert
query the insert id of the callback action is returned and not the
expected one (the one for the model object that was just created).
