### PR TITLE
Change order of operations in _fetch_table()

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -165,16 +165,6 @@ class MY_Model extends CI_Model
     }
 
     /**
-     * Return a count of every row in the table
-     *
-     * @return integer
-     */
-    public function count_all()
-    {
-        return $this->db->count_all($this->_table);
-    }
-
-    /**
      * Insert a new row into the table. $data should be an associative array
      * of data to be inserted. Returns newly created ID.
      */


### PR DESCRIPTION
Changed the order from get_class,preg_replace,strtolower,plural
to get_class,strtolower,preg_replace,plural
The difference is clear if get_class returns 'Inventory_Model', in which case
the original code would return 'inventory_models' instead of 'inventories' as
the table name
