### PR TITLE
Fix changes to data being lost in after_get callback for single record queries

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -93,7 +93,7 @@ class MY_Model extends CI_Model
                         ->{$this->_return_type()}();
         $this->_temporary_return_type = $this->return_type;
 
-        $this->_run_after_callbacks('get', array( $row ));
+        $row = $this->_run_after_callbacks('get', array( $row ));
 
         return $row;
     }
@@ -112,7 +112,7 @@ class MY_Model extends CI_Model
                         ->{$this->_return_type()}();
         $this->_temporary_return_type = $this->return_type;
 
-        $this->_run_after_callbacks('get', array( $row ));
+        $row = $this->_run_after_callbacks('get', array( $row ));
 
         return $row;
     }


### PR DESCRIPTION
Here's a basic example of a callback I'm using:

``` php
protected function convert_date_to_dmy($data)
{
    if (is_object($data))
    {
        $date = DateTime::createFromFormat('Y-m-d', $data->date);
        $data->date = $date->format('d/m/y');
    }
    else
    {
        $date = DateTime::createFromFormat('Y-m-d', $data['date']);
        $data['date'] = $date->format('d/m/y');
    }
    return $data;
}
```

Even though this will return the correctly converted date format, that data is only currently used in the `get_all()` / `get_many()` / `get_many_by()` methods. This quick fix makes the `after_get` callbacks work as expected for the `get()` and `get_by()` methods too.
