### PR TITLE
Correction for Built-in Observer timestamps example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ The timestamps (MySQL compatible) `created_at` and `updated_at` are now availabl
 
     class Post_model extends MY_Model
     {
-        public $before_create = array( 'created_at' );
-        public $before_update = array( 'created_at', 'updated_at' );
+        public $before_create = array( 'created_at', 'updated_at' );
+        public $before_update = array( 'updated_at' );
     }
 
 Unit Tests


### PR DESCRIPTION
The Built-in Observer timestamps example in the README are not quite right. The sample does not set the **updated_at** on **$before_create**, and also shows modifying the **created_at** on **$before_update**. AFAIK, it should be like this: 

```
class Post_model extends MY_Model
{
    public $before_create = array( 'created_at', 'updated_at' );
    public $before_update = array( 'updated_at' );
}
```
