### PR TITLE
_return_type() method visibility

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -800,7 +800,7 @@ class MY_Model extends CI_Model
     /**
      * Set WHERE parameters, cleverly
      */
-    private function _set_where($params)
+    protected function _set_where($params)
     {
         if (count($params) == 1)
         {


### PR DESCRIPTION
Changed visibility of _return_type() method from "private" to "protected".
This will allow child classes to utilize the _return_type() method.
