### PR TITLE
Allow for where array in get_by() & get_many_by()

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -143,6 +143,7 @@ class MY_Model extends CI_Model
     public function get_by()
     {
         $where = func_get_args();
+        if (is_array($where[0])) {$where = $where[0];}
         $this->_set_where($where);
 
         if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
@@ -182,6 +183,7 @@ class MY_Model extends CI_Model
     public function get_many_by()
     {
         $where = func_get_args();
+        if (is_array($where[0])) {$where = $where[0];}
         $this->_set_where($where);
 
         if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)


### PR DESCRIPTION
instead of allowing only one where filter, this allows passing a where array as the first param to `get_by()` and `get_many_by()`.
