### PR TITLE
Make the soft-delete values configurable

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -37,6 +37,8 @@ class MY_Model extends CI_Model
      */
     protected $soft_delete = FALSE;
     protected $soft_delete_key = 'deleted';
+    protected $soft_delete_deleted_value = TRUE;
+    protected $soft_delete_default_value = FALSE;
     protected $_temporary_with_deleted = FALSE;
 
     /**
@@ -123,7 +125,7 @@ class MY_Model extends CI_Model
 
         if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
         {
-            $this->db->where($this->soft_delete_key, FALSE);
+            $this->db->where($this->soft_delete_key, $this->soft_delete_default_value);
         }
 
         $row = $this->db->where($this->primary_key, $primary_value)
@@ -148,7 +150,7 @@ class MY_Model extends CI_Model
 
         if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
         {
-            $this->db->where($this->soft_delete_key, FALSE);
+            $this->db->where($this->soft_delete_key, $this->soft_delete_default_value);
         }
 
         $this->trigger('before_get');
@@ -170,7 +172,7 @@ class MY_Model extends CI_Model
     {
         if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
         {
-            $this->db->where($this->soft_delete_key, FALSE);
+            $this->db->where($this->soft_delete_key, $this->soft_delete_default_value);
         }
 
         $this->db->where_in($this->primary_key, $values);
@@ -188,7 +190,7 @@ class MY_Model extends CI_Model
 
         if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
         {
-            $this->db->where($this->soft_delete_key, FALSE);
+            $this->db->where($this->soft_delete_key, $this->soft_delete_default_value);
         }
 
         return $this->get_all();
@@ -204,7 +206,7 @@ class MY_Model extends CI_Model
 
         if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
         {
-            $this->db->where($this->soft_delete_key, FALSE);
+            $this->db->where($this->soft_delete_key, $this->soft_delete_default_value);
         }
 
         $result = $this->db->get($this->_table)
@@ -372,7 +374,7 @@ class MY_Model extends CI_Model
 
         if ($this->soft_delete)
         {
-            $result = $this->db->update($this->_table, array( $this->soft_delete_key => TRUE ));
+            $result = $this->db->update($this->_table, array( $this->soft_delete_key => $this->soft_delete_deleted_value ));
         }
         else
         {
@@ -396,7 +398,7 @@ class MY_Model extends CI_Model
 
         if ($this->soft_delete)
         {
-            $result = $this->db->update($this->_table, array( $this->soft_delete_key => TRUE ));
+            $result = $this->db->update($this->_table, array( $this->soft_delete_key => $this->soft_delete_deleted_value ));
         }
         else
         {
@@ -419,7 +421,7 @@ class MY_Model extends CI_Model
 
         if ($this->soft_delete)
         {
-            $result = $this->db->update($this->_table, array( $this->soft_delete_key => TRUE ));
+            $result = $this->db->update($this->_table, array( $this->soft_delete_key => $this->soft_delete_deleted_value ));
         }
         else
         {
@@ -528,7 +530,7 @@ class MY_Model extends CI_Model
 
         if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
         {
-            $this->db->where($this->soft_delete_key, FALSE);
+            $this->db->where($this->soft_delete_key, $this->soft_delete_default_value);
         }
 
         $result = $this->db->select(array($key, $value))


### PR DESCRIPTION
I'm currently working with a DB schema where the DBA wants a time-stamp when a record is deleted. If the value of 'deleted' is NULL, the record is considered live. If the value of 'deleted' is a time-stamp it is considered deleted data and ignored for most queries, but can be used when doing temporal analysis of the data.
