### PR TITLE
Fix for prepping functions

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -804,7 +804,7 @@ class MY_Model extends CI_Model
 
                 if ($this->form_validation->run() === TRUE)
                 {
-                    return $data;
+                    return $_POST;
                 }
                 else
                 {
@@ -815,7 +815,7 @@ class MY_Model extends CI_Model
             {
                 if ($this->form_validation->run($this->validate) === TRUE)
                 {
-                    return $data;
+                    return $_POST;
                 }
                 else
                 {


### PR DESCRIPTION
Return $_POST array from validate method so that we get the data to which the prepping functions are applied like xss_clean and stuff.
