### PR TITLE
Relate

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -476,7 +476,14 @@ class MY_Model extends CI_Model
             if (in_array($relationship, $this->_with))
             {
                 $this->load->model($options['model']);
-                $row->{$relationship} = $this->{$options['model']}->get($row->{$options['primary_key']});
+                if (is_object($row))
+                {
+                    $row->{$relationship} = $this->{$options['model']}->get($row->{$options['primary_key']});
+                }
+                else
+                {
+                    $row[$relationship] = $this->{$options['model']}->get($row[$options['primary_key']]);
+                }
             }
         }
 
@@ -496,7 +503,14 @@ class MY_Model extends CI_Model
             if (in_array($relationship, $this->_with))
             {
                 $this->load->model($options['model']);
-                $row->{$relationship} = $this->{$options['model']}->get_many_by($options['primary_key'], $row->{$this->primary_key});
+                if (is_object($row))
+                {
+                    $row->{$relationship} = $this->{$options['model']}->get_many_by($options['primary_key'], $row->{$this->primary_key});
+                }
+                else
+                {
+                    $row[$relationship] = $this->{$options['model']}->get_many_by($options['primary_key'], $row[$this->primary_key]);
+                }
             }
         }
 


### PR DESCRIPTION
If return type is set to array the relate function breaks with a non-object error. Added a conditional to cater for arrays.
