### PR TITLE
Feature/eager relations

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -862,37 +862,41 @@ class MY_Model extends CI_Model
      */
     protected function _set_where($params)
     {
-        if (count($params) == 1)
+        if (count($params) == 1 && is_array($params[0]))
         {
-            if (is_array($params))
+            foreach ($params[0] as $field => $filter)
             {
-                foreach ($params[0] as $field => $filter)
+                if (is_array($filter))
                 {
-                    if (is_array($filter))
+                    $this->db->where_in($field, $filter);
+                }
+                else
+                {
+                    if (is_int($field))
                     {
-                        $this->db->where_in($field, $filter);
+                        $this->db->where($filter);
                     }
                     else
                     {
-                        if (is_int($field))
-                        {
-                            $this->db->where($filter);
-                        }
-                        else
-                        {
-                            $this->db->where($field, $filter);
-                        }
+                        $this->db->where($field, $filter);
                     }
                 }
             }
-            else
-            {
-                $this->db->where($params[0]);  
-            }
+        } 
+        else if (count($params) == 1)
+        {
+            $this->db->where($filter);
         }
         else
         {
-            $this->db->where($params[0], $params[1]);
+            if (is_array($params[1]))
+            {
+                $this->db->where_in($params[0], $params[1]);    
+            }
+            else
+            {
+                $this->db->where($params[0], $params[1]);
+            }
         }
     }
 

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -864,7 +864,31 @@ class MY_Model extends CI_Model
     {
         if (count($params) == 1)
         {
-            $this->db->where($params[0]);
+            if (is_array($params))
+            {
+                foreach ($params[0] as $field => $filter)
+                {
+                    if (is_array($filter))
+                    {
+                        $this->db->where_in($field, $filter);
+                    }
+                    else
+                    {
+                        if (is_int($field))
+                        {
+                            $this->db->where($filter);
+                        }
+                        else
+                        {
+                            $this->db->where($field, $filter);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                $this->db->where($params[0]);  
+            }
         }
         else
         {

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -899,7 +899,7 @@ class MY_Model extends CI_Model
         } 
         else if (count($params) == 1)
         {
-            $this->db->where($filter);
+            $this->db->where($params[0]);
         }
         else
         {

--- a/tests/MY_Model_test.php
+++ b/tests/MY_Model_test.php
@@ -27,6 +27,7 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
+        m::close();
         unset($this->model);
     }
 
@@ -484,92 +485,110 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
      * RELATIONSHIPS
      * ------------------------------------------------------------ */
 
-    public function test_belongs_to()
-    {
-        $object = (object)array( 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43 );
-        $author_object = (object)array( 'id' => 43, 'name' => 'Jamie', 'age' => 20 );
-        $expected_object = (object)array( 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43, 'author' => $author_object );
+    // public function test_belongs_to()
+    // {
+    //     $object          = (object)array( 'id' => 1, 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43 );
+    //     $author_object   = (object)array( 'id' => 43, 'name' => 'Jamie', 'age' => 20 );
+    //     $expected_object = (object)array( 'id' => 1, 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43, 'author' => $author_object );
 
-        $self =& $this;
+    //     $this->model = new Belongs_to_model();
+    //     $this->model->_database = m::mock(new MY_Model_Mock_DB());
+    //     $this->model->load = m::mock(new MY_Model_Mock_Loader());
+        
+    //     $this->model->author_model = new Author_model();
+    //     $this->model->author_model->_database = m::mock(new MY_Model_Mock_DB());
 
-        $this->model = new Belongs_to_model();
-        $this->model->_database = $this->getMock('MY_Model_Mock_DB');
-        $this->model->load = $this->getMock('MY_Model_Mock_Loader');
+    //     $this->model->_database
+    //         ->shouldReceive('where')
+    //         ->with('id', 1)
+    //         ->andReturn($this->model->_database);
+    //     $this->model->_database
+    //         ->shouldReceive('get')
+    //         ->andReturn($this->model->_database);
+    //     $this->model->_database
+    //         ->shouldReceive('row')
+    //         ->andReturn($object);
 
-        $author_model = new Author_model();
-        $author_model->_database = $this->getMockBuilder('MY_Model_Mock_DB')->setMockClassName('Other_Mock_MY_Model_Mock_DB')->getMock();
+    //     $this->model->author_model->_database
+    //         ->shouldReceive('where_in')
+    //         ->with('id', array(43))
+    //         ->andReturn($this->model->author_model->_database);
+    //     $this->model->author_model->_database
+    //         ->shouldReceive('get')
+    //         ->andReturn($this->model->author_model->_database);
+    //     $this->model->author_model->_database
+    //         ->shouldReceive('result')
+    //         ->andReturn(array($author_object));
 
-        $author_model->_database->expects($this->once())->method('where')->will($this->returnValue($author_model->_database));
-        $author_model->_database->expects($this->once())->method('get')->will($this->returnValue($author_model->_database));
-
-        $this->model->_database->expects($this->once())->method('where')->will($this->returnValue($this->model->_database));
-        $this->model->_database->expects($this->once())->method('get')->will($this->returnValue($this->model->_database));
-
-        $this->model->_database->expects($this->once())->method('row')->will($this->returnValue($object));
-        $author_model->_database->expects($this->once())->method('row')->will($this->returnValue($author_object));
-
-        $this->model->load->expects($this->once())->method('model')->with('author_model')
-                          ->will($this->returnCallback(function() use ($self, $author_model){
-                              $self->model->author_model = $author_model;
-                          }));
-
-        $this->assertEquals($expected_object, $this->model->with('author')->get(1));
-    }
+    //     $this->assertEquals($expected_object, $this->model->with('author')->get(1));
+    // }
 
     public function test_has_many()
     {
         $object = (object)array( 'id' => 1, 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43 );
         
-        $comment_object = (object)array( 'id' => 1, 'comment' => 'A comment' );
-        $comment_object_2 = (object)array( 'id' => 2, 'comment' => 'Another comment' );
+        $comment_object = (object)array( 'id' => 1, 'comment' => 'A comment', 'thing_id' => 1 );
+        $comment_object_2 = (object)array( 'id' => 2, 'comment' => 'Another comment', 'thing_id' => 1 );
 
         $expected_object = (object)array( 'id' => 1, 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43,
                                           'comments' => array( $comment_object, $comment_object_2 ) );
 
-        $self =& $this;
-
         $this->model = new Belongs_to_model();
-        $this->model->_database = $this->getMock('MY_Model_Mock_DB');
-        $this->model->load = $this->getMock('MY_Model_Mock_Loader');
+        $this->model->_database = m::mock(new MY_Model_Mock_DB());
+        $this->model->load = m::mock(new MY_Model_Mock_Loader());
 
-        $comment_model = new Author_model();
-        $comment_model->_database = $this->getMockBuilder('MY_Model_Mock_DB')->setMockClassName('Another_Mock_MY_Model_Mock_DB')->getMock();
+        $this->model->comment_model = new Comment_model();
+        $this->model->comment_model->_database = m::mock(new MY_Model_Mock_DB());
 
-        $comment_model->_database->expects($this->once())->method('where')->with('comment_id', 1)->will($this->returnValue($comment_model->_database));
-        $comment_model->_database->expects($this->once())->method('get')->will($this->returnValue($comment_model->_database));
+        $this->model->_database
+            ->shouldReceive('where')
+            ->with('id', 1)
+            ->andReturn($this->model->_database);
+        $this->model->_database
+            ->shouldReceive('get')
+            ->andReturn($this->model->_database);
+        $this->model->_database
+            ->shouldReceive('row')
+            ->andReturn($object);
 
-        $this->model->_database->expects($this->once())->method('where')->will($this->returnValue($this->model->_database));
-        $this->model->_database->expects($this->once())->method('get')->will($this->returnValue($this->model->_database));
-
-        $this->model->_database->expects($this->once())->method('row')->will($this->returnValue($object));
-        $comment_model->_database->expects($this->once())->method('result')->will($this->returnValue(array( $comment_object, $comment_object_2 )));
-
-        $this->model->load->expects($this->once())->method('model')->with('comment_model')
-                          ->will($this->returnCallback(function() use ($self, $comment_model){
-                              $self->model->comment_model = $comment_model;
-                          }));
+        $this->model->comment_model->_database
+            ->shouldReceive('where_in')
+            ->with('thing_id', array(1))
+            ->andReturn($this->model->comment_model->_database);
+        $this->model->comment_model->_database
+            ->shouldReceive('get')
+            ->andReturn($this->model->comment_model->_database);
+        $this->model->comment_model->_database
+            ->shouldReceive('result')
+            ->andReturn(array($comment_object, $comment_object_2));
 
         $this->assertEquals($expected_object, $this->model->with('comments')->get(1));
     }
-
+    
     public function test_relate_works_with_objects_and_arrays()
     {
-        $data = array( 'name' => 'Jamie', 'author_id' => 1 );
-        $author = 'related object';
+        $data = array( 'id' => 1, 'name' => 'Jamie', 'author_id' => 108 );
+        $author = array('id' => 108, 'name' => 'related object');
 
         $this->model = new Belongs_to_model();
+        $this->set_private($this->model, '_temporary_result', array($data));
+
         $this->model->author_model = m::mock(new Author_model());
-        $this->model->author_model->shouldReceive('get')
-                                  ->andReturn($author);
+        $this->model->author_model->shouldReceive('get_many')
+                                  ->andReturn(array($author));
 
         $obj = $this->model->with('author')->relate((object)$data);
+        $this->set_private($this->model, '_eager_cache', array());
+        $this->set_private($this->model, 'return_type', 'array');
         $arr = $this->model->with('author')->relate($data);
         
         $this->assertInternalType('object', $obj);
         $this->assertInternalType('array', $arr);
+        
         $this->assertTrue(isset($obj->author));
         $this->assertTrue(isset($arr['author']));
-        $this->assertEquals($author, $obj->author);
+        
+        $this->assertEquals((object)$author, $obj->author);
         $this->assertEquals($author, $arr['author']);
     }
 
@@ -910,6 +929,12 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
     /* --------------------------------------------------------------
      * TEST UTILITIES
      * ------------------------------------------------------------ */
+
+    protected function set_private($object, $property, $value) {
+        $reflector = new ReflectionProperty(get_class($object), $property);
+        $reflector->setAccessible(true);
+        $reflector->setValue($object, $value);
+    }
 
     protected function _expect_get()
     {

--- a/tests/MY_Model_test.php
+++ b/tests/MY_Model_test.php
@@ -73,6 +73,65 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->model->get_by('some_column', 'some_value'), 'fake_record_here');
     }
 
+    public function test_get_by_using_array()
+    {
+        $this->model->db->expects($this->once())
+                        ->method('where_in')
+                        ->with($this->equalTo('some_column'), array('some_value', 'some_other_value'))
+                        ->will($this->returnValue($this->model->db));
+        $this->_expect_get();
+        $this->model->db->expects($this->once())
+                        ->method('row')
+                        ->will($this->returnValue('fake_record_here'));
+
+        $this->assertEquals($this->model->get_by('some_column', array('some_value', 'some_other_value')), 'fake_record_here');
+    }
+
+    public function test_get_by_using_string()
+    {
+        $this->model->db->expects($this->once())
+                        ->method('where')
+                        ->with($this->equalTo('some_column != some_value'))
+                        ->will($this->returnValue($this->model->db));
+        $this->_expect_get();
+        $this->model->db->expects($this->once())
+                        ->method('row')
+                        ->will($this->returnValue('fake_record_here'));
+
+        $this->assertEquals($this->model->get_by('some_column != some_value'), 'fake_record_here');
+    }
+
+    public function test_get_by_using_mixed_params()
+    {
+        $where = array(
+            'some_column == some_value',
+            'some_other_column' => array('some_value', 'some_other_value'),
+            'another_column'    => 'some_value',
+        );
+
+        $this->model->db->expects($this->at(0))
+                        ->method('where')
+                        ->with('some_column == some_value')
+                        ->will($this->returnValue($this->model->db));
+
+        $this->model->db->expects($this->once())
+                        ->method('where_in')
+                        ->with($this->equalTo('some_other_column'), array('some_value', 'some_other_value'))
+                        ->will($this->returnValue($this->model->db));
+
+        $this->model->db->expects($this->at(2))
+                        ->method('where')
+                        ->with($this->equalTo('another_column'), $this->equalTo('some_value'))
+                        ->will($this->returnValue($this->model->db));
+
+        $this->_expect_get();
+        $this->model->db->expects($this->once())
+                        ->method('row')
+                        ->will($this->returnValue('fake_record_here'));
+
+        $this->assertEquals($this->model->get_by($where), 'fake_record_here');
+    }
+
     public function test_get_many()
     {
         $this->model->db->expects($this->once())

--- a/tests/MY_Model_test.php
+++ b/tests/MY_Model_test.php
@@ -485,43 +485,43 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
      * RELATIONSHIPS
      * ------------------------------------------------------------ */
 
-    // public function test_belongs_to()
-    // {
-    //     $object          = (object)array( 'id' => 1, 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43 );
-    //     $author_object   = (object)array( 'id' => 43, 'name' => 'Jamie', 'age' => 20 );
-    //     $expected_object = (object)array( 'id' => 1, 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43, 'author' => $author_object );
+    public function test_belongs_to()
+    {
+        $object          = (object)array( 'id' => 1, 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43 );
+        $author_object   = (object)array( 'id' => 43, 'name' => 'Jamie', 'age' => 20 );
+        $expected_object = (object)array( 'id' => 1, 'title' => 'A Post', 'created_at' => time(), 'author_id' => 43, 'author' => $author_object );
 
-    //     $this->model = new Belongs_to_model();
-    //     $this->model->_database = m::mock(new MY_Model_Mock_DB());
-    //     $this->model->load = m::mock(new MY_Model_Mock_Loader());
+        $this->model = new Belongs_to_model();
+        $this->model->_database = m::mock(new MY_Model_Mock_DB());
+        $this->model->load = m::mock(new MY_Model_Mock_Loader());
         
-    //     $this->model->author_model = new Author_model();
-    //     $this->model->author_model->_database = m::mock(new MY_Model_Mock_DB());
+        $this->model->author_model = new Author_model();
+        $this->model->author_model->_database = m::mock(new MY_Model_Mock_DB());
 
-    //     $this->model->_database
-    //         ->shouldReceive('where')
-    //         ->with('id', 1)
-    //         ->andReturn($this->model->_database);
-    //     $this->model->_database
-    //         ->shouldReceive('get')
-    //         ->andReturn($this->model->_database);
-    //     $this->model->_database
-    //         ->shouldReceive('row')
-    //         ->andReturn($object);
+        $this->model->_database
+            ->shouldReceive('where')
+            ->with('id', 1)
+            ->andReturn($this->model->_database);
+        $this->model->_database
+            ->shouldReceive('get')
+            ->andReturn($this->model->_database);
+        $this->model->_database
+            ->shouldReceive('row')
+            ->andReturn($object);
 
-    //     $this->model->author_model->_database
-    //         ->shouldReceive('where_in')
-    //         ->with('id', array(43))
-    //         ->andReturn($this->model->author_model->_database);
-    //     $this->model->author_model->_database
-    //         ->shouldReceive('get')
-    //         ->andReturn($this->model->author_model->_database);
-    //     $this->model->author_model->_database
-    //         ->shouldReceive('result')
-    //         ->andReturn(array($author_object));
+        $this->model->author_model->_database
+            ->shouldReceive('where_in')
+            ->with('id', array(43))
+            ->andReturn($this->model->author_model->_database);
+        $this->model->author_model->_database
+            ->shouldReceive('get')
+            ->andReturn($this->model->author_model->_database);
+        $this->model->author_model->_database
+            ->shouldReceive('result')
+            ->andReturn(array($author_object));
 
-    //     $this->assertEquals($expected_object, $this->model->with('author')->get(1));
-    // }
+        $this->assertEquals($expected_object, $this->model->with('author')->get(1));
+    }
 
     public function test_has_many()
     {

--- a/tests/MY_Model_test.php
+++ b/tests/MY_Model_test.php
@@ -511,6 +511,7 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
 
         $this->model->author_model->_database
             ->shouldReceive('where_in')
+            ->once()
             ->with('id', array(43))
             ->andReturn($this->model->author_model->_database);
         $this->model->author_model->_database
@@ -553,6 +554,7 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
 
         $this->model->comment_model->_database
             ->shouldReceive('where_in')
+            ->once()
             ->with('thing_id', array(1))
             ->andReturn($this->model->comment_model->_database);
         $this->model->comment_model->_database

--- a/tests/support/models/relationship_model.php
+++ b/tests/support/models/relationship_model.php
@@ -13,11 +13,17 @@
 
 class Belongs_to_model extends MY_Model
 {
+    protected $_table  = 'things';
     public $belongs_to = array( 'author' );
-    public $has_many = array( 'comments' );
+    public $has_many   = array( 'comments' );
 }
 
 class Author_model extends MY_Model
 {
     protected $_table = 'authors';
+}
+
+class Comment_model extends MY_Model
+{
+    protected $_table = 'comments';
 }

--- a/tests/support/test_helper.php
+++ b/tests/support/test_helper.php
@@ -49,8 +49,12 @@ class MY_Model_Mock_Loader
 /**
  * We also need to fake the inflector
  */
-function singular($name)
+function singular($name = 'comments')
 {
+    if ($name == 'things')
+    {
+        return 'thing';
+    }
     return 'comment';
 }
 


### PR DESCRIPTION
Currently if you have to pull **n** records with a relation to some other object that would result in **n+1** queries to the database. With eager loading of relations you would have a constant number of 2 queries being run.
I would appreciate it if somebody can take a look at the tests, because most of my time was not spent on the feature but producing the tests. I would constantly have method not found errors on "where_in" even when I mocked it (seemingly) properly and used it on the next line to test it if it's mocked ok. So I'm kinda nervous that I botched the tests somehow. I tried to make sure they test the proper things, but with this "where_in" error driving me mad I could finish producing the test ensuring only 1 query is run on the relation even when no results are being returned by it.
