### PR TITLE
Fix DB connection issue, add supporting documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,22 @@ The timestamps (MySQL compatible) `created_at` and `updated_at` are now availabl
         public $after_get = array( 'unserialize(seat_types)' );
     }
 
+Database Connection
+-------------------
+
+The class will automatically use the default database connection, and even load it for you if you haven't yet.
+
+You can specify a database connection on a per-model basis by declaring the _$\_db\_group_ instance variable. This is equivalent to calling `$this->db->database($this->_db_group, TRUE)`.
+
+See ["Connecting to your Database"](http://ellislab.com/codeigniter/user-guide/database/connecting.html) for more information.
+
+```php
+class Post_model extends MY_Model
+{
+    public $_db_group = 'group_name';
+}
+```
+
 Unit Tests
 ----------
 

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -21,14 +21,20 @@ class MY_Model extends CI_Model
     protected $_table;
 
     /**
-     * Database conn object; will use default connection
-     * unless overridden
+     * Specify a database group to manually connect this model
+     * to the specified DB. You can pass either the group name
+     * as defined in application/config/database.php, or a
+     * config array of the same format (basically the same thing
+     * you can pass to $this->load->database()). If left empty,
+     * the default DB will be used.
      */
-    protected $_db;
+    protected $_db_group;
     
     /**
-     * Local Database conn object; will use instead of $this->db
-     * so that we don't override current database connection
+     * The database connection object. Will be set to the default
+     * connection unless $this->_db_group is specified. This allows
+     * individual models to use different DBs without overwriting
+     * CI's global $this->db connection.
      */
     public $_database;
 
@@ -862,22 +868,28 @@ class MY_Model extends CI_Model
         }
     }
 
-    /* --------------------------------------------------------------
-     * MULTIPLE DB LOADING
-     * ------------------------------------------------------------ */
-
+    /**
+     * Establish the database connection.
+     */
     private function _set_database()
     {
-        if (!$this->_db)
+        // Was a DB group specified by the user?
+        if ($this->_db_group !== NULL)
         {
-            $this->_database = $this->load->database();
+            $this->_database = $this->load->database($this->_db_group, TRUE, TRUE);
         }
+        // No DB group specified, use the default connection.
         else
         {
-            $this->_database = $this->load->database($this->_db, TRUE);
+            // Has the default connection been loaded yet?
+            if ( ! isset($this->db) OR ! is_object($this->db))
+            {
+                $this->load->database('', FALSE, TRUE);
+            }
+
+            $this->_database = $this->db;
         }
     }
-
 
     /**
      * Set WHERE parameters, cleverly

--- a/tests/support/test_helper.php
+++ b/tests/support/test_helper.php
@@ -26,6 +26,9 @@ class CI_Model
     public function __construct()
     {
         $this->load = new CI_Loader();
+
+        // Pretend CI has a loaded DB already.
+        $this->db = new MY_Model_Mock_DB();
     }
 }
 


### PR DESCRIPTION
Unfortunately #104, while having the good idea to give per-model DB connection capabilities, broke the simplest use case of MY_Model:

``` php
class Post_model extends MY_Model {}

class Example extends CI_Controller {

    public function index()
    {
        $this->load->database();
        $this->load->model('post_model', 'posts');

        $posts = $this->posts->get_all();
    }
}
```

Result:

> Fatal error: Call to a member function get() on a non-object in /application/core/MY_Model.php on line 216

The problem is this chunk of code:

``` php
if (!$this->_db)
{
    $this->_database = $this->load->database();
}
```

`$this->load->database()` won't return anything except `FALSE` or `NULL`, so no DB connection is being assigned to `$_database`, when we kind of need one! :)

I've revised the code to default to the original global database property, loading it if necessary. I've also updated the comments and README.md to appropriately describe the functionality, including the ability to pass a full `$config` array of DB settings if desired.

**The unit testing right now kind of sucks.** From what I can tell, the only reason `$_database` is public is so unit testing can work properly, and that's dumb. Unfortunately I'm not really well-versed in unit testing, and CI isn't exactly the easiest thing to write tests for, so I didn't think of a suitable fix right away. I didn't want to wait for that to submit this PR, given the fatal error nature of it.
