### PR TITLE
if validation fails during update_by() the where clause carries over into subsequent queries

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -342,12 +342,12 @@ class MY_Model extends CI_Model
     {
         $args = func_get_args();
         $data = array_pop($args);
-        $this->_set_where($args);
 
         $data = $this->trigger('before_update', $data);
 
         if ($this->validate($data) !== FALSE)
         {
+            $this->_set_where($args);
             $result = $this->_database->set($data)
                                ->update($this->_table);
             $this->trigger('after_update', array($data, $result));


### PR DESCRIPTION
This is because the db->where is set before validation is checked, so in event of failure the where is set, but the query is not run.
