### PR TITLE
If model is under a path, it cannot be loaded by using $this->{$options['model']}.

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -472,6 +472,9 @@ class MY_Model extends CI_Model
 
     public function relate($row)
     {
+		if (empty($row))
+		    return $row;
+		
         foreach ($this->belongs_to as $key => $value)
         {
             if (is_string($value))


### PR DESCRIPTION
Trying to fix the issue if a model is under a path, use relationship as name of the model.
