### PR TITLE
#issue 64 - Fixed validate function so native functions work and no xss. 

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -825,6 +825,7 @@ class MY_Model extends CI_Model
         
         if(!empty($this->validate))
         {
+       	    unset($_POST);
             foreach($data as $key => $val)
             {
                 $_POST[$key] = $val;
@@ -838,7 +839,11 @@ class MY_Model extends CI_Model
 
                 if ($this->form_validation->run() === TRUE)
                 {
-                    return $_POST;
+                    foreach($_POST as $key => $val)
+                    {
+                    	$data[$key] = $value;
+                    }
+                    return $data;
                 }
                 else
                 {
@@ -849,7 +854,11 @@ class MY_Model extends CI_Model
             {
                 if ($this->form_validation->run($this->validate) === TRUE)
                 {
-                    return $_POST;
+                    foreach($_POST as $key => $val)
+                    {
+                    	$data[$key] = $value;
+                    }
+                    return $data;
                 }
                 else
                 {


### PR DESCRIPTION
Set the validate function to return $_POST instead of data, as the prepped data is transfered back to $_POST.

Unless we do this, something like 
       <script>alert('ola')</script>
is passing into the db even with a rule like 'trim|strip_tags'
