### PR TITLE
Made model suffix '_model' configurable.

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -88,6 +88,11 @@ class MY_Model extends CI_Model
      */
     protected $return_type = 'object';
     protected $_temporary_return_type = NULL;
+    
+    /**
+     * Model suffix for relationships
+     */
+    protected $model_suffix = '_model';
 
     /* --------------------------------------------------------------
      * GENERIC METHODS
@@ -457,7 +462,7 @@ class MY_Model extends CI_Model
             if (is_string($value))
             {
                 $relationship = $value;
-                $options = array( 'primary_key' => $value . '_id', 'model' => $value . '_model' );
+                $options = array( 'primary_key' => $value . '_id', 'model' => $value . $this->model_suffix);
             }
             else
             {
@@ -467,15 +472,15 @@ class MY_Model extends CI_Model
 
             if (in_array($relationship, $this->_with))
             {
-                $this->load->model($options['model'], $relationship . '_model');
+                $this->load->model($options['model'], $relationship . $this->model_suffix);
 
                 if (is_object($row))
                 {
-                    $row->{$relationship} = $this->{$relationship . '_model'}->get($row->{$options['primary_key']});
+                    $row->{$relationship} = $this->{$relationship . $this->model_suffix}->get($row->{$options['primary_key']});
                 }
                 else
                 {
-                    $row[$relationship] = $this->{$relationship . '_model'}->get($row[$options['primary_key']]);
+                    $row[$relationship] = $this->{$relationship . $this->model_suffix}->get($row[$options['primary_key']]);
                 }
             }
         }
@@ -485,7 +490,7 @@ class MY_Model extends CI_Model
             if (is_string($value))
             {
                 $relationship = $value;
-                $options = array( 'primary_key' => singular($this->_table) . '_id', 'model' => singular($value) . '_model' );
+                $options = array( 'primary_key' => singular($this->_table) . '_id', 'model' => singular($value) . $this->model_suffix);
             }
             else
             {
@@ -495,15 +500,15 @@ class MY_Model extends CI_Model
 
             if (in_array($relationship, $this->_with))
             {
-                $this->load->model($options['model'], $relationship . '_model');
+                $this->load->model($options['model'], $relationship . $this->model_suffix);
 
                 if (is_object($row))
                 {
-                    $row->{$relationship} = $this->{$relationship . '_model'}->get_many_by($options['primary_key'], $row->{$this->primary_key});
+                    $row->{$relationship} = $this->{$relationship . $this->model_suffix}->get_many_by($options['primary_key'], $row->{$this->primary_key});
                 }
                 else
                 {
-                    $row[$relationship] = $this->{$relationship . '_model'}->get_many_by($options['primary_key'], $row[$this->primary_key]);
+                    $row[$relationship] = $this->{$relationship . $this->model_suffix}->get_many_by($options['primary_key'], $row[$this->primary_key]);
                 }
             }
         }
@@ -855,7 +860,7 @@ class MY_Model extends CI_Model
     {
         if ($this->_table == NULL)
         {
-            $this->_table = plural(preg_replace('/(_m|_model)?$/', '', strtolower(get_class($this))));
+            $this->_table = plural(preg_replace('/(_m|' . $this->model_suffix . ')?$/', '', strtolower(get_class($this))));
         }
     }
 


### PR DESCRIPTION
The hardcoded '_model' suffix used in relate() enforces us to always use this suffix in our models; I made it configurable to have more freedom.
