### PR TITLE
Using get_many or get_many_by produce duplicate deleted = 0

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -156,11 +156,6 @@ class MY_Model extends CI_Model
      */
     public function get_many($values)
     {
-        if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
-        {
-            $this->_database->where($this->soft_delete_key, (bool)$this->_temporary_only_deleted);
-        }
-
         $this->_database->where_in($this->primary_key, $values);
 
         return $this->get_all();
@@ -172,12 +167,7 @@ class MY_Model extends CI_Model
     public function get_many_by()
     {
         $where = func_get_args();
-
-        if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
-        {
-            $this->_database->where($this->soft_delete_key, (bool)$this->_temporary_only_deleted);
-        }
-
+        
         $this->_set_where($where);
 
         return $this->get_all();


### PR DESCRIPTION
using get_many or get_many_by produce duplicate sql  `deleted` = 0

if ($this->soft_delete && $this->_temporary_with_deleted !== TRUE)
{
    $this->_database->where($this->soft_delete_key, (bool)$this->_temporary_only_deleted);
}

since get_all already implement this method
to prevent duplidate `delted` = 0 in sql query.
