### PR TITLE
Feature/test for trim validation

### DIFF
--- a/tests/MY_Model_test.php
+++ b/tests/MY_Model_test.php
@@ -548,6 +548,16 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
         return $model;
     }
 
+    public function test_validate_correctly_trims_data()
+    {
+        $this->model = $this->_validatable_model();
+        $input = array( 'name' => 'Jamie ', 'sexyness' => ' loads' );
+        $expected_output = array( 'name' => 'Jamie', 'sexyness' => 'loads' );
+
+        $this->assertEquals($this->model->validate($input), $expected_output);
+
+    }
+
     /* --------------------------------------------------------------
      * SOFT DELETE
      * ------------------------------------------------------------ */    

--- a/tests/support/models/validated_model.php
+++ b/tests/support/models/validated_model.php
@@ -10,7 +10,7 @@
 class Validated_model extends MY_Model
 {
 	public $validate = array(
-		array( 'field' => 'name', 'label' => 'Name', 'rules' => 'required' ),
-		array( 'field' => 'sexyness', 'label' => 'Sexyness', 'rules' => 'required' )
+		array( 'field' => 'name', 'label' => 'Name', 'rules' => 'trim|required' ),
+		array( 'field' => 'sexyness', 'label' => 'Sexyness', 'rules' => 'trim|required' )
 	);
 }


### PR DESCRIPTION
I've added a test for trim to show that it doesn't currently work the same as CodeIgniter does.

I believe this also shows where the `return $_POST;` lines came from in @a0788a9dee82909265f776996f9f636cbfaf450f as that fixes the issue, but isn't really a suitable solution.

Is this the expected functionality? Should I trim inside of before_insert/before_update?