### PR TITLE
fetch_primary_key implemented with ignoring the base_class instance

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -31,7 +31,7 @@ class MY_Model extends CI_Model
      * This model's default primary key or unique identifier.
      * Used by the get(), update() and delete() functions.
      */
-    protected $primary_key = 'id';
+    protected $primary_key = NULL;
 
     /**
      * Support for soft deletes and this model's 'deleted' key
@@ -89,6 +89,8 @@ class MY_Model extends CI_Model
     protected $return_type = 'object';
     protected $_temporary_return_type = NULL;
 
+    private $_base_model_instance = NULL;
+
     /* --------------------------------------------------------------
      * GENERIC METHODS
      * ------------------------------------------------------------ */
@@ -106,6 +108,11 @@ class MY_Model extends CI_Model
         $this->_fetch_table();
 
         $this->_database = $this->db;
+        $this->_fetch_primary_key();
+
+        if($this->primary_key == null && $this->is_base_model_instance()) {
+            return;
+        }
 
         array_unshift($this->before_create, 'protect_attributes');
         array_unshift($this->before_update, 'protect_attributes');
@@ -611,6 +618,14 @@ class MY_Model extends CI_Model
         return $this->_table;
     }
 
+    /**
+     * Getter for the primary key
+     */
+    public function primary_key()
+    {
+        return $this->primary_key;
+    }
+
     /* --------------------------------------------------------------
      * GLOBAL SCOPES
      * ------------------------------------------------------------ */
@@ -863,12 +878,25 @@ class MY_Model extends CI_Model
     /**
      * Guess the primary key for current table
      */
-    private function _fetch_primary_key()
+    protected function _fetch_primary_key()
     {
-        if($this->primary_key == NULl)
+        if($this->is_base_model_instance()) {
+            return;
+        }
+
+        if ($this->primary_key == NULL && $this->_database)
         {
             $this->primary_key = $this->_database->query("SHOW KEYS FROM `".$this->_table."` WHERE Key_name = 'PRIMARY'")->row()->Column_name;
         }
+    }
+
+    private function is_base_model_instance()
+    {
+        if($this->_base_model_instance === null) {
+            $this->_base_model_instance = get_class($this) == __CLASS__;
+        }
+
+        return $this->_base_model_instance;
     }
 
     /**

--- a/tests/MY_Model_test.php
+++ b/tests/MY_Model_test.php
@@ -41,6 +41,24 @@ class MY_Model_tests extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->model->table(), 'records');
     }
 
+    public function test_constructor_guess_the_primary_key()
+    {
+        $this->model = new Book_model($this->model->_database, 'id');
+
+        $this->model->_database->expects($this->once())
+            ->method('query')
+            ->with($this->equalTo("SHOW KEYS FROM `books` WHERE Key_name = 'PRIMARY'"))
+            ->will($this->returnValue($this->model->_database))
+        ;
+        $this->model->_database->expects($this->once())
+            ->method('row')
+            ->will($this->returnValue((object)array('Column_name'=>'fake_primary_key')));
+
+        $this->model = $this->model->__construct($this->model->_database);
+
+        $this->assertEquals($this->model->primary_key(), 'fake_primary_key');
+    }
+
     /* --------------------------------------------------------------
      * CRUD INTERFACE
      * ------------------------------------------------------------ */

--- a/tests/support/database.php
+++ b/tests/support/database.php
@@ -31,6 +31,7 @@ class MY_Model_Mock_DB
     public function count_all_results() { }
     public function count_all() { }
     public function truncate() { }
+    public function query() { }
 
     /**
      * CI_DB_Result

--- a/tests/support/models/after_callback_model.php
+++ b/tests/support/models/after_callback_model.php
@@ -18,6 +18,7 @@ class After_callback_model extends MY_Model
     protected $after_update = array('test_throw');
     protected $after_get = array('test_data_callback', 'test_data_callback_two');
     protected $after_delete = array('test_throw');
+    protected $primary_key = 'id';
 
     protected function test_throw($row)
     {

--- a/tests/support/models/before_callback_model.php
+++ b/tests/support/models/before_callback_model.php
@@ -18,6 +18,7 @@ class Before_callback_model extends MY_Model
     protected $before_update = array('test_data_callback', 'test_data_callback_two');
     protected $before_get = array('test_throw');
     protected $before_delete = array('test_throw');
+    protected $primary_key = 'id';
 
     protected function test_throw($row)
     {

--- a/tests/support/models/book_model.php
+++ b/tests/support/models/book_model.php
@@ -1,0 +1,16 @@
+<?php
+
+class Book_model extends MY_Model {
+
+    protected $_table = 'books';
+
+    public function __construct($database, $key = NULL)
+    {
+        $this->primary_key = $key;
+        $this->_database = $database;
+        $this->_fetch_primary_key();
+
+        return $this;
+    }
+
+}

--- a/tests/support/models/callback_parameter_model.php
+++ b/tests/support/models/callback_parameter_model.php
@@ -15,6 +15,7 @@
 class Callback_parameter_model extends MY_Model
 {
 	public $callback = array('some_callback(some_param,another_param)');
+    protected $primary_key = 'id';
 
 	public function some_method()
 	{

--- a/tests/support/models/protected_attributes_model.php
+++ b/tests/support/models/protected_attributes_model.php
@@ -14,4 +14,5 @@
 class Protected_attributes_model extends MY_Model
 {
 	public $protected_attributes = array( 'id', 'hash' );
+    protected $primary_key = 'id';
 }

--- a/tests/support/models/record_model.php
+++ b/tests/support/models/record_model.php
@@ -1,3 +1,5 @@
 <?php
 
-class Record_model extends MY_Model { }
+class Record_model extends MY_Model {
+    protected $primary_key = 'id';
+}

--- a/tests/support/models/relationship_model.php
+++ b/tests/support/models/relationship_model.php
@@ -15,9 +15,11 @@ class Belongs_to_model extends MY_Model
 {
     public $belongs_to = array( 'author' );
     public $has_many = array( 'comments' );
+    protected $primary_key = 'id';
 }
 
 class Author_model extends MY_Model
 {
     protected $_table = 'authors';
+    protected $primary_key = 'id';
 }

--- a/tests/support/models/serialised_data_model.php
+++ b/tests/support/models/serialised_data_model.php
@@ -15,4 +15,5 @@ class Serialised_data_model extends MY_Model
 {
 	public $before_create = array( 'serialize(data)' );
 	public $before_update = array( 'serialize(data)' );
+    protected $primary_key = 'id';
 }

--- a/tests/support/models/soft_delete_model.php
+++ b/tests/support/models/soft_delete_model.php
@@ -3,6 +3,7 @@
 class Soft_delete_model extends MY_Model
 {
 	protected $soft_delete = TRUE;
+    protected $primary_key = 'id';
 
 	public function __construct($key = 'deleted')
 	{

--- a/tests/support/models/validated_model.php
+++ b/tests/support/models/validated_model.php
@@ -9,6 +9,7 @@
 
 class Validated_model extends MY_Model
 {
+    protected $primary_key = 'id';
 	public $validate = array(
 		array( 'field' => 'name', 'label' => 'Name', 'rules' => 'required' ),
 		array( 'field' => 'sexyness', 'label' => 'Sexyness', 'rules' => 'required' )


### PR DESCRIPTION
Guessing primary key implemented with ignoring the base_class instance. 
There was a bug reported with the previous implementation. 
The problem occurred because Codeigniter creates a instance of the MY_Model base class.

Now before processing further we are checking if it is a valid model or not.
