### PR TITLE
execute relate method at start of after-get triggers

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -430,7 +430,7 @@ class MY_Model extends CI_Model
 
         if (!in_array('relate', $this->after_get))
         {
-            $this->after_get[] = 'relate';
+            array_unshift($this->after_get, 'relate');
         }
 
         return $this;


### PR DESCRIPTION
Hello,
it's better to execute relate method at start of after-get triggers because maybe we need related data after make relation.

Thanks
