### PR TITLE
Add isset conditional for serialize observer

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -694,7 +694,7 @@ class MY_Model extends CI_Model
     {
         foreach ($this->callback_parameters as $column)
         {
-            $row[$column] = serialize($row[$column]);
+            if (isset($row[$column])) $row[$column] = serialize($row[$column]);
         }
 
         return $row;


### PR DESCRIPTION
Without a conditional to serialize, then on update a column is created (empty), serialized, and overrides previously stored data.
