### PR TITLE
Enables composed key update

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -257,6 +257,8 @@ class MY_Model extends CI_Model
 
         if ($data !== FALSE)
         {
+            if(!is_array($primary_value)) $primary_value = [$this->primary_key => $primary_value];
+            
             $result = $this->_database->where($this->primary_key, $primary_value)
                                ->set($data)
                                ->update($this->_table);

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -257,7 +257,7 @@ class MY_Model extends CI_Model
 
         if ($data !== FALSE)
         {
-            if(!is_array($primary_value)) $primary_value = [$this->primary_key => $primary_value];
+            if(!is_array($primary_value)) $primary_value = array($this->primary_key => $primary_value);
             
             $result = $this->_database->where($this->primary_key, $primary_value)
                                ->set($data)

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -259,7 +259,7 @@ class MY_Model extends CI_Model
         {
             if(!is_array($primary_value)) $primary_value = array($this->primary_key => $primary_value);
             
-            $result = $this->_database->where($this->primary_key, $primary_value)
+            $result = $this->_database->where($primary_value)
                                ->set($data)
                                ->update($this->_table);
 


### PR DESCRIPTION
By providing an associative array it is possible to update by composed (multi-column) primary_key
If primary_value is not an array it will use the default primary_key
Fixes #151