### PR TITLE
Capitalization consistency for 'NULL'

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -865,7 +865,7 @@ class MY_Model extends CI_Model
      */
     private function _fetch_primary_key()
     {
-        if($this->primary_key == NULl)
+        if($this->primary_key == NULL)
         {
             $this->primary_key = $this->_database->query("SHOW KEYS FROM `".$this->_table."` WHERE Key_name = 'PRIMARY'")->row()->Column_name;
         }


### PR DESCRIPTION
 NULL is a case-insensitive constant, so this doesn't affect the functionality of anything. Just tidying up appearances (was "NULl")