### PR TITLE
Auto assign ZERO(0) to soft delete key if not specified by user

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -210,6 +210,15 @@ class MY_Model extends CI_Model
         {
             $data = $this->validate($data);
         }
+		
+		/* Auto assign ZERO(0) to soft delete key if not specified by user*/
+		if ($this->soft_delete)
+        {
+            if (!isset($data[$this->soft_delete_key]))
+            {
+                $data[$this->soft_delete_key] = 0;
+            }
+        }
 
         if ($data !== FALSE)
         {


### PR DESCRIPTION
eliminating problems from unspecified deleted status (NULL) (unable to get / get all the records) when the "deleted" key is not specified.