### PR TITLE
Added insert_batch to use with the mapped table in the model

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -251,7 +251,7 @@ class MY_Model extends CI_Model
      */
     public function insert_batch($data) 
     {
-	$result = $this->db->insert_batch($this->_table, $data);
+	$result = $this->_database->insert_batch($this->_table, $data);
 
 	return $result;
     }

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -244,6 +244,19 @@ class MY_Model extends CI_Model
     }
 
     /**
+     * Insert rows in batch into the table instead of doing one by one.
+     * This method is faster than "insert_many", but beware of passing unvalidated data, since this
+     * method does not deploy class validation nor db trigger execution either.
+     * Returns true on success or false otherwise.
+     */
+    public function insert_batch($data) 
+    {
+	$result = $this->db->insert_batch($this->_table, $data);
+
+	return $result;
+    }
+
+    /**
      * Updated a record based on the primary value.
      */
     public function update($primary_value, $data, $skip_validation = FALSE)


### PR DESCRIPTION
Hello, this CI Extension Class helped me a lot for encapsulating some native plumbing db model methods. When I searched for a "insert_batch()" method in this extended class (for further info: https://ellislab.com/codeigniter/user-guide/database/active_record.html#insert) , I didn't found it and I didn't want to use the native CI method, because I had to pass 2 parameters, just like this: 

$this->db->insert_batch(string $table_name, array $data);

Searching I've found the method insert_many(), but it also loops to add one by one. That why I created this method in the extension class, since it's faster adding records in batch, saving time and requests with DB Server.

With this new merthod, you anyone can use it like this, since it uses default table name:

$this->my_model->insert_batch(array $data);

Keep in mind the data must be validated before passing to this method.
