### PR TITLE
Specify a database connection on a per-model basis by declaring instance variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,14 +315,14 @@ Database Connection
 
 The class will automatically use the default database connection, and even load it for you if you haven't yet.
 
-You can specify a database connection on a per-model basis by declaring the _$\_db\_group_ instance variable. This is equivalent to calling `$this->db->database($this->_db_group, TRUE)`.
+You can specify a database connection on a per-model basis by declaring the _$\_database_ instance variable. This is equivalent to calling `$this->db->database($this->_database, TRUE)`.
 
 See ["Connecting to your Database"](http://ellislab.com/codeigniter/user-guide/database/connecting.html) for more information.
 
 ```php
 class Post_model extends MY_Model
 {
-    public $_db_group = 'group_name';
+    public $_database = 'group_name';
 }
 ```
 

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -21,8 +21,8 @@ class MY_Model extends CI_Model
     protected $_table;
 
     /**
-     * The database connection object. Will be set to the default
-     * connection. This allows individual models to use different DBs
+     * The database connection object. Will be set to the default group
+     * connection. This allows individual models to use different DB groups
      * without overwriting CI's global $this->db connection.
      */
     public $_database;
@@ -105,6 +105,9 @@ class MY_Model extends CI_Model
 
         $this->_fetch_table();
 
+        if($this->_database){
+            $this->db = $this->load->database($this->_database, TRUE);
+        }
         $this->_database = $this->db;
 
         array_unshift($this->before_create, 'protect_attributes');


### PR DESCRIPTION
The class will automatically use the default database connection, and even load it for you if you haven't yet.

You can specify a database connection on a per-model basis by declaring the _$\_database_ instance variable. This is equivalent to calling `$this->db->database($this->_database, TRUE)`.


```php
class Post_model extends MY_Model
{
    public $_database = 'group_name';
}
```