### PR TITLE
Run validation for each model independent of the state of _POST or CI…

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -103,6 +103,8 @@ class MY_Model extends CI_Model
 
         $this->load->helper('inflector');
 
+		$this->load->library('form_validation');
+
         $this->_fetch_table();
 
         $this->_database = $this->db;
@@ -112,12 +114,17 @@ class MY_Model extends CI_Model
 
         $this->_temporary_return_type = $this->return_type;
 		
-		// Load our own instance of CI form validation
-		$this->load->library('form_validation');
-		if (property_exists($this, 'form_validation'))
+		if (function_exists('get_instance'))
 		{
-			$form_validation_class = get_class($this->form_validation);
-			$this->form_validation = new $form_validation_class();
+			$CI =& get_instance();
+			
+			if (property_exists($CI, 'form_validation'))
+			{
+				// Create our own instance of CI form validation
+				$form_validation_class = get_class($CI->form_validation);
+				$this->form_validation = new $form_validation_class();
+			}
+			
 		}
     }
 

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -111,6 +111,14 @@ class MY_Model extends CI_Model
         array_unshift($this->before_update, 'protect_attributes');
 
         $this->_temporary_return_type = $this->return_type;
+		
+		// Load our own instance of CI form validation
+		$this->load->library('form_validation');
+		if (property_exists($this, 'form_validation'))
+		{
+			$form_validation_class = get_class($this->form_validation);
+			$this->form_validation = new $form_validation_class();
+		}
     }
 
     /* --------------------------------------------------------------
@@ -811,12 +819,14 @@ class MY_Model extends CI_Model
 
         if(!empty($this->validate))
         {
+			// Temporarily reset the contents of $_POST
+            $post_tmp = $_POST;
+            $_POST = array();
+			
             foreach($data as $key => $val)
             {
                 $_POST[$key] = $val;
             }
-
-            $this->load->library('form_validation');
 
             if(is_array($this->validate))
             {
@@ -842,6 +852,9 @@ class MY_Model extends CI_Model
                     return FALSE;
                 }
             }
+			
+			// Restore $_POST to its initial state
+            $_POST = $post_tmp;
         }
         else
         {


### PR DESCRIPTION
…::form_validation.
## The Issue

When a controller only validates one model and does not validate other input, it is sufficient to assume `$_POST` and `$this->form_validation` only serve the purpose of the model. However each controller and action may have various models which it would like to validate. It also may want to validate form input separately. This creates a problem.

Ideally, there should be a `1:1` correspondence between each instance of MY_Model and its form validator, as well as a 1:1 correspondence between an instance of MY_Model and the _POST data it validates.
### A case study

I often have API controllers which use the CI Form_validation library to validate and sanitize endpoint POST input. Let's suppose they validate a field called `comment`, and we have a model for Posts which has validation rules but does not have a field called comment.

``` php
public function some_controller_method()
{
    $this->load->library('form_validation');
    $this->form_validation->set_rules('comment', 'Comment', 'required|min_length[10]');

    if ( ! $this->form_validation->run())
    {
         // Comment was missing
         // Let's just suppose that we do something to some post in that case
        if ($this->posts_model->validate(array('some_posts_field' => 'blah blah'))
        {
         // Fails, even though posts_model is still technically valid
        ...
        }
    }
}
```

Here you can see that `$this->form_validation` is being used both for the `posts_model` validation as well as the controller input validation. When `$this->posts_model->validate()` fires, Form_validation sees a rule for 'comment' and checks if it exists in the POST data. It fails to see the comment field, and so `posts_model->validate()` fails unexpectedly.
## the solution

I get around this issue, as well as some others, by 
1. Temporarily unsetting / resetting `$_POST` on calls to `validate()`
2. Creating an instance of form_validation for each model in its constructor. 
